### PR TITLE
Update SimpleUtils.java

### DIFF
--- a/common/src/main/java/willatendo/simplelibrary/server/util/SimpleUtils.java
+++ b/common/src/main/java/willatendo/simplelibrary/server/util/SimpleUtils.java
@@ -113,7 +113,7 @@ public final class SimpleUtils {
     }
 
     public static void registerAllItems(SimpleRegistry<Item> deferredRegister, SimpleRegistry<Block> blocks, SimpleHolder<? extends Block>... exceptions) {
-        for (SimpleHolder<? extends Block> block : blocks.getEntriesView().stream().filter(block -> !SimpleUtils.toList(exceptions).contains(block)).toList()) {
+        for (SimpleHolder<? extends Block> block : blocks.getEntriesView().stream().filter(block -> !SimpleUtils.toList(exceptions).contains(block)).collect(Collections.toList())) {
             deferredRegister.register(block.getId().getPath(), () -> new BlockItem(block.get(), new Item.Properties()));
         }
     }


### PR DESCRIPTION
Because blocks.getEntriesView is backed by a set and not a list, so I think toList is giving an error. This should be able to be resolved by using the Collector API instead as was previously standard.

This also might only be an issue with loading the roses mod, so it might be better to make a new function if this function is in use and working elsewhere in other repos.

I havent tested this, but based on analysis of the code and the errors, I think this is the problem.

Let me know if it doesnt work or if it leads to other issues and I will gladly help however i can, and im sorry if this is unhelpful.